### PR TITLE
Add macOS installation instruction

### DIFF
--- a/content/getting_started.md
+++ b/content/getting_started.md
@@ -3,6 +3,14 @@ title = "Getting started"
 weight = 0
 +++
 
+## MacOS
+
+Using the package manager [MacPorts](https://www.macports.org)
+```sh
+sudo port install blades
+```
+
+## From Source
 If you have the Rust toolchain installed, you can install Blades from [crates.io](https://crates.io/crates/blades)
 ```sh
 cargo install blades


### PR DESCRIPTION
MacPorts have a package https://ports.macports.org/port/blades/ witch make installation of blades easier for peoples not familiar to rust.

I didn't find one for brew.